### PR TITLE
readme: add missing "go" marker

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ cron_parser.go import https://github.com/robfig/cron/blob/master/parser.go , tha
 
 ## Usage
 
-```
+```go
 package main
 
 // test for crontab spec


### PR DESCRIPTION
This enables proper syntax highlighting on GitHub.