### PR TITLE
Change t.Sub to time.Until

### DIFF
--- a/scheduler.go
+++ b/scheduler.go
@@ -330,7 +330,7 @@ func (j *JobModel) run(wg *sync.WaitGroup) {
 
 	// parse crontab spec
 	due, err := getNextDue(j.spec)
-	interval := due.Sub(time.Now())
+	interval := time.Until(due)
 	if err != nil {
 		panic(err.Error())
 	}
@@ -349,7 +349,7 @@ func (j *JobModel) run(wg *sync.WaitGroup) {
 		case <-timer.C:
 			due, _ := getNextDue(j.spec)
 			timer.Reset(
-				due.Sub(time.Now()),
+				time.Until(due),
 			)
 
 			if j.async {


### PR DESCRIPTION
Hi! According to best practices you can use method [`time.Until`](https://golang.org/pkg/time/#Until) instead `date.Sub(time.Now())`. `time.Until` is [shortcut](https://golang.org/src/time/time.go?s=28450:28477#L906) for date.Sub(time.Now()). So, you can review this change and merge if it looks good to you